### PR TITLE
feat: Convert CommonJS to ES6 modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,4 +186,6 @@ class DRange {
     }
 }
 
-module.exports = DRange;
+export { DRange };
+
+export default DRange;

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const DRange = require('..');
+import assert from 'node:assert';
+import { DRange } from '../src/drange.js';
 
 /* eslint indent: ["warn", 4] */
 describe('empty drange', () => {


### PR DESCRIPTION
The codebase has been updated from CommonJS to ES6 modules. This includes
changes in the main library file and the test file. The DRange class is now
exported as a named and default export.
